### PR TITLE
Fix bug causing left half of upload bar to grow at 2x speed.

### DIFF
--- a/nelson/uploadcallbacks.py
+++ b/nelson/uploadcallbacks.py
@@ -12,7 +12,7 @@ def progressbar_callback(monitor):
   total_bytes = monitor.encoder.len
   pct = float(monitor.bytes_read) / total_bytes
 
-  l_fill = "{:<27}".format("=" * min(int((min(0.5, pct) / 0.5) / 0.5 * 30), 27))
+  l_fill = "{:<27}".format("=" * min(int(min(0.5, pct) / 0.5 * 30), 27))
   p_fill = "{:^4}".format(str(int(pct * 100)) + "%")
   r_fill = "{:<27}".format("=" * min(int(min(pct - 0.5, 0.5) / 0.5 * 30), 27))
   ratio = "{!s}/{!s}".format(monitor.bytes_read, total_bytes)


### PR DESCRIPTION
With the change, l_fill function output:

```
pct   len
---   ---
0.0     0
0.05    3
0.1     6
0.15    9
0.2    12
0.25   15
0.3    18
0.35   21
0.4    24
0.45   27
0.5    27
0.55   27
```