### PR TITLE
Propagate zipfile root through Submission classes (v0.4.2)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+v0.4.2, 2017-09-01  -- Fix alternate zipfile root
 v0.4.1, 2017-09-01  -- Allowing alternate zipfile root
 v0.3.0, 2017-09-01  -- Attempt at python3 compatibility
 v0.2.1, 2016-12-26  -- Initial release.

--- a/nelson/gtomscs.py
+++ b/nelson/gtomscs.py
@@ -57,6 +57,7 @@ class Submission(AbstractSubmission):
                session,
                filenames,
                max_zip_size = 8 << 20,
+               zipfile_root = os.path.dirname(sys.argv[0]),
                upload_progress_callback = None,
                environment = 'production'):
 
@@ -67,6 +68,7 @@ class Submission(AbstractSubmission):
     super(Submission, self).__init__(session,
                                      filenames,
                                      max_zip_size = max_zip_size,
+                                     zipfile_root = zipfile_root,
                                      upload_progress_callback = upload_progress_callback)
 
   def project_name(self):

--- a/nelson/udacity.py
+++ b/nelson/udacity.py
@@ -56,6 +56,7 @@ class Submission(AbstractSubmission):
                session,
                filenames,
                max_zip_size = 8 << 20,
+               zipfile_root = os.path.dirname(sys.argv[0]),
                upload_progress_callback = None,
                environment = 'production'):
 
@@ -66,6 +67,7 @@ class Submission(AbstractSubmission):
     super(Submission, self).__init__(session,
                                      filenames,
                                      max_zip_size = max_zip_size,
+                                     zipfile_root = zipfile_root,
                                      upload_progress_callback = upload_progress_callback)
 
   def project_name(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='nelson',
-    version='0.4.1',
+    version='0.4.2',
     author='S. Charles Brubaker',
     author_email='cb@udacity.com',
     packages=['nelson'],


### PR DESCRIPTION
This fixes passing the zipfile_root parameter through Submission objects.